### PR TITLE
removing banner from home page (not logged in)

### DIFF
--- a/lms/templates/index.html
+++ b/lms/templates/index.html
@@ -10,44 +10,6 @@ from openedx.core.djangolib.markup import HTML, Text
 
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="home">
-      <header>
-        <div class="outer-wrapper">
-          <div class="title">
-            <div class="heading-group">
-              % if homepage_overlay_html:
-                ${homepage_overlay_html | n, decode.utf8}
-              % else:
-                  ## Translators: 'Open edX' is a registered trademark, please keep this untranslated. See http://open.edx.org for more information.
-                  <h1>${Text(_(u"Welcome to the MITx platform!"))}</h1>
-                  ## Translators: 'Open edX' is a registered trademark, please keep this untranslated. See http://open.edx.org for more information.
-                  <p>${_("MITx is designed for the MIT community and runs on Open edX.")}</p>
-              % endif
-            </div>
-            % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
-              <div class="course-search">
-                <form method="get" action="/courses">
-                  <label><span class="sr">${_("Search for a course")}</span>
-                    <input class="search-input" name="search_query" type="text" placeholder="${_("Search for a course")}"></input>
-                  </label>
-                  <button class="search-button" type="submit">
-                    <span class="icon fa fa-search" aria-hidden="true"></span><span class="sr">${_("Search")}</span>
-                  </button>
-                </form>
-              </div>
-            % endif
-
-          </div>
-
-          % if show_homepage_promo_video:
-            <a href="#video-modal" class="media" rel="leanModal">
-              <div class="hero">
-                <div class="play-intro"></div>
-              </div>
-            </a>
-          % endif
-        </div>
-
-      </header>
       <%include file="${courses_list}" />
 
     </section>


### PR DESCRIPTION
Removing the home page banner, at the request of Ike and Sheryl.

closes https://github.com/mitodl/salt-ops/issues/174

Before:
<img width="1392" alt="screen shot 2016-08-30 at 9 37 46 pm" src="https://cloud.githubusercontent.com/assets/430126/18112968/362fb23c-6efa-11e6-9ac8-9563dc9ecc1e.png">

After:
<img width="1392" alt="screen shot 2016-08-30 at 9 38 12 pm" src="https://cloud.githubusercontent.com/assets/430126/18112967/3623355c-6efa-11e6-971d-861ba65e9f5a.png">
