### PR TITLE
Updated reference for main lms sass stylesheet

### DIFF
--- a/lms/static/sass/lms-main.scss
+++ b/lms/static/sass/lms-main.scss
@@ -2,4 +2,4 @@
 @import 'overrides';
 
 // import the rest of the application
-@import 'lms/static/sass/lms-main';
+@import 'lms/static/sass/lms-main-v2';


### PR DESCRIPTION
The name of the `lms-main` stylesheet has changed in
Eucalyptus. Updated the reference to resolve a build error.