### PR TITLE
Changing enrollment e-mail to work with MITx configuration

### DIFF
--- a/lms/templates/emails/enroll_email_allowedmessage.txt
+++ b/lms/templates/emails/enroll_email_allowedmessage.txt
@@ -1,0 +1,43 @@
+<%! from django.utils.translation import ugettext as _ %>
+
+${_("Dear student,")}
+
+${_("You have been invited to join {course_name} at {site_name} by a "
+	"member of the course staff.").format(
+		course_name=display_name or course.display_name_with_default_escaped,
+		site_name=site_name
+	)}
+% if is_shib_course:
+% if auto_enroll:
+
+${_("To access the course visit {course_url} and login.").format(course_url=course_url)}
+% elif course_about_url is not None:
+
+${_("To access the course visit {course_about_url} and register for the course.").format(
+		course_about_url=course_about_url)}
+% endif
+% else:
+
+${_("To finish your registration, please visit {registration_url} and fill "
+	"out the registration form making sure to use {email_address} in the E-mail field.").format(
+		registration_url=registration_url,
+		email_address=email_address
+	)}
+% if auto_enroll:
+${_("Once you have registered and activated your account, you will see "
+	"{course_name} listed on your dashboard.").format(
+		course_name=display_name or course.display_name_with_default_escaped
+	)}
+% elif course_about_url is not None:
+${_("Once you have registered and activated your account, visit {course_about_url} "
+	"to join the course.").format(course_about_url=course_about_url)}
+% else:
+${_("You can then enroll in {course_name}.").format(course_name=display_name or course.display_name_with_default_escaped)}
+% endif
+% endif
+
+----
+${_("This email was automatically sent from {site_name} to "
+	"{email_address}").format(
+		site_name=site_name, email_address=email_address
+	)}

--- a/lms/templates/emails/enroll_email_allowedmessage.txt
+++ b/lms/templates/emails/enroll_email_allowedmessage.txt
@@ -18,18 +18,19 @@ ${_("To access the course visit {course_about_url} and register for the course."
 % endif
 % else:
 
-${_("To finish your registration, please visit {registration_url} and fill "
+${_("To finish your registration, please visit {site_name}/dashboard You will need to "
+        "login with Touchstone to access this page. If you do not have a Touchstone "
+	"account, please contact your instructor for detailed directions."
 	"out the registration form making sure to use {email_address} in the E-mail field.").format(
-		registration_url=registration_url,
-		email_address=email_address
+		site_name=site_name
 	)}
 % if auto_enroll:
-${_("Once you have registered and activated your account, you will see "
+${_("Once you have logged in with Touchstone, you will see "
 	"{course_name} listed on your dashboard.").format(
 		course_name=display_name or course.display_name_with_default_escaped
 	)}
 % elif course_about_url is not None:
-${_("Once you have registered and activated your account, visit {course_about_url} "
+${_("Once you have logged in with Touchstone, visit {course_about_url} "
 	"to join the course.").format(course_about_url=course_about_url)}
 % else:
 ${_("You can then enroll in {course_name}.").format(course_name=display_name or course.display_name_with_default_escaped)}

--- a/lms/templates/emails/enroll_email_allowedmessage.txt
+++ b/lms/templates/emails/enroll_email_allowedmessage.txt
@@ -19,7 +19,7 @@ ${_("To access the course visit {course_about_url} and register for the course."
 % else:
 
 ${_("To finish your registration, please visit {site_name}/dashboard You will need to "
-        "You will need to  login with Touchstone to access this page. If you "
+        "You will need to login with Touchstone to access this page. If you "
         "do not have a Touchstone account, please contact your instructor for "
         "detailed directions.").format(
             site_name=site_name

--- a/lms/templates/emails/enroll_email_allowedmessage.txt
+++ b/lms/templates/emails/enroll_email_allowedmessage.txt
@@ -18,7 +18,7 @@ ${_("To access the course visit {course_about_url} and register for the course."
 % endif
 % else:
 
-${_("To finish your registration, please visit {site_name}/dashboard You will need to "
+${_("To finish your registration, please visit {site_name}/dashboard\n"
         "You will need to login with Touchstone to access this page. If you "
         "do not have a Touchstone account, please contact your instructor for "
         "detailed directions.").format(

--- a/lms/templates/emails/enroll_email_allowedmessage.txt
+++ b/lms/templates/emails/enroll_email_allowedmessage.txt
@@ -19,11 +19,11 @@ ${_("To access the course visit {course_about_url} and register for the course."
 % else:
 
 ${_("To finish your registration, please visit {site_name}/dashboard You will need to "
-        "login with Touchstone to access this page. If you do not have a Touchstone "
-	"account, please contact your instructor for detailed directions."
-	"out the registration form making sure to use {email_address} in the E-mail field.").format(
-		site_name=site_name
-	)}
+        "You will need to  login with Touchstone to access this page. If you "
+        "do not have a Touchstone account, please contact your instructor for "
+        "detailed directions.").format(
+            site_name=site_name
+    )}
 % if auto_enroll:
 ${_("Once you have logged in with Touchstone, you will see "
 	"{course_name} listed on your dashboard.").format(

--- a/lms/templates/emails/enroll_email_allowedmessage.txt
+++ b/lms/templates/emails/enroll_email_allowedmessage.txt
@@ -3,10 +3,10 @@
 ${_("Dear student,")}
 
 ${_("You have been invited to join {course_name} at {site_name} by a "
-	"member of the course staff.").format(
-		course_name=display_name or course.display_name_with_default_escaped,
-		site_name=site_name
-	)}
+    "member of the course staff.").format(
+        course_name=display_name or course.display_name_with_default_escaped,
+        site_name=site_name
+    )}
 % if is_shib_course:
 % if auto_enroll:
 
@@ -14,7 +14,7 @@ ${_("To access the course visit {course_url} and login.").format(course_url=cour
 % elif course_about_url is not None:
 
 ${_("To access the course visit {course_about_url} and register for the course.").format(
-		course_about_url=course_about_url)}
+        course_about_url=course_about_url)}
 % endif
 % else:
 
@@ -26,12 +26,12 @@ ${_("To finish your registration, please visit {site_name}/dashboard You will ne
     )}
 % if auto_enroll:
 ${_("Once you have logged in with Touchstone, you will see "
-	"{course_name} listed on your dashboard.").format(
-		course_name=display_name or course.display_name_with_default_escaped
-	)}
+    "{course_name} listed on your dashboard.").format(
+        course_name=display_name or course.display_name_with_default_escaped
+    )}
 % elif course_about_url is not None:
 ${_("Once you have logged in with Touchstone, visit {course_about_url} "
-	"to join the course.").format(course_about_url=course_about_url)}
+    "to join the course.").format(course_about_url=course_about_url)}
 % else:
 ${_("You can then enroll in {course_name}.").format(course_name=display_name or course.display_name_with_default_escaped)}
 % endif
@@ -39,6 +39,6 @@ ${_("You can then enroll in {course_name}.").format(course_name=display_name or 
 
 ----
 ${_("This email was automatically sent from {site_name} to "
-	"{email_address}").format(
-		site_name=site_name, email_address=email_address
-	)}
+    "{email_address}").format(
+        site_name=site_name, email_address=email_address
+    )}


### PR DESCRIPTION
#### What are the relevant tickets?

Partially fixes https://github.com/mitodl/salt-ops/issues/386

#### What's this PR do?

Overrides the enrollment e-mail sent from lms.mitx.mit.edu

#### How should this be manually tested?

Update the theme in a devstack and check to see that the enrollment e-mail is overridden. 

#### Any background context you want to provide?

I'm not sure where we are with changing the django setting for sitename. In order for this to actually fix salt-ops#386 that needs to be changed as well. 
