### PR TITLE
Add tos link to lms

### DIFF
--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -26,6 +26,11 @@
             <a href="${footer['openedx_link']['url']}" title="${footer['openedx_link']['title']}">
               <img alt="${footer['openedx_link']['title']}" src="${footer['openedx_link']['image']}" width="140">
             </a>
+              % for item_num, link in enumerate(footer['legal_links'], start=1):
+                %if link['title'] == "Terms of Service":
+                    <a href="${link['url']}" style="font-size: 11px;margin-left: 6px;">${link['title']}</a>
+                %endif
+              % endfor
           </div>
           % endif
       </div>


### PR DESCRIPTION
fixes https://github.com/mitodl/salt-ops/issues/307

It adds tos link to lms footer

@pdpinch 

<img width="882" alt="screen shot 2017-08-10 at 8 38 36 pm" src="https://user-images.githubusercontent.com/10431250/29178838-3257f526-7e0c-11e7-97e1-d8641d3843a3.png">
