### PR TITLE
Added error pages to theme

### DIFF
--- a/cms/templates/404.html
+++ b/cms/templates/404.html
@@ -1,0 +1,30 @@
+<%page expression_filter="h"/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<%inherit file="base.html" />
+<%block name="title">${_("Page Not Found")}</%block>
+<%block name="bodyclass">view-util util-404</%block>
+
+
+<%block name="content">
+<div class="wrapper-content wrapper">
+  <section class="content">
+    <header>
+      <h1 class="title title-1">${_("Page not found")}</h1>
+    </header>
+    <article class="content-primary" role="main">
+      <p>
+      ${_('The page that you were looking for was not found.')}
+      ${Text(_('Go back to the {homepage} or let us know about any pages that may have been moved at {email}.')).format(
+        homepage=HTML('<a href="/">homepage</a>'),
+        email=HTML('<a href="mailto:{address}">{address}</a>').format(
+          address=Text(settings.TECH_SUPPORT_EMAIL)
+        )
+      )}
+      </p>
+    </article>
+  </section>
+</div>
+</%block>

--- a/cms/templates/500.html
+++ b/cms/templates/500.html
@@ -1,0 +1,41 @@
+<%page expression_filter="h"/>
+<%!
+from openedx.core.djangolib.markup import HTML, Text
+from django.utils.translation import ugettext as _
+%>
+<%inherit file="base.html" />
+<%block name="title">
+${Text(_("{studio_name} Server Error")).format(
+  studio_name=Text(settings.STUDIO_SHORT_NAME)
+)}
+</%block>
+<%block name="bodyclass">view-util util-500</%block>
+
+<%block name="content">
+<div class="wrapper-content wrapper">
+  <section class="content">
+    <header>
+      <h1 class="title title-1">
+        ${Text(_(u"The {em_start}{studio_name}{em_end} servers encountered an error")).format(
+          em_start=HTML('<em>'),
+          em_end=HTML('</em>'),
+          studio_name=Text(settings.STUDIO_SHORT_NAME),
+        )}
+      </h1>
+    </header>
+    <article class="content-primary" role="main">
+      <p>
+        ${Text(_("An error occurred in {studio_name} and the page could not be loaded. Please try again in a few moments.")).format(
+          studio_name=Text(settings.STUDIO_SHORT_NAME),
+        )}
+        ${_("We've logged the error and our staff is currently working to resolve this error as soon as possible.")}
+        ${Text(_(u'If the problem persists, please email us at {email_link}.')).format(
+          email_link=HTML(u'<a href="mailto:{email_address}">{email_address}</a>').format(
+            email_address=Text(settings.TECH_SUPPORT_EMAIL),
+          )
+        )}
+      </p>
+    </article>
+  </section>
+</div>
+</%block>

--- a/cms/templates/error.html
+++ b/cms/templates/error.html
@@ -1,0 +1,41 @@
+<%page expression_filter="h"/>
+<%inherit file="base.html" />
+<%!
+from django.utils.translation import ugettext as _
+from django.core.urlresolvers import reverse
+from django.conf import settings
+%>
+<%block name="bodyclass">error</%block>
+<%block name="title">
+  % if error == '404':
+    404 - ${_("Page Not Found")}
+  % elif error == '500':
+    500 - ${_("Internal Server Error")}
+  % endif
+</%block>
+
+<%!
+help_link_start = '<a href="mailto:{email}">'.format(email=settings.TECH_SUPPORT_EMAIL)
+help_link_end = '</a>'
+%>
+
+<%block name="content">
+  <article class="error-prompt">
+    % if error == '404':
+      <h1>${_("The Page You Requested Page Cannot be Found")}</h1>
+      <p class="description">${Text(_("We're sorry. We couldn't find the {studio_name} page you're looking for. You may want to return to the {studio_name} Dashboard and try again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.")).format(
+          studio_name=settings.STUDIO_SHORT_NAME,
+          link_start=HTML(help_link_start),
+          link_end=HTML(help_link_end),
+        )}</p>
+    % elif error == '500':
+      <h1>${_("The Server Encountered an Error")}</h1>
+      <p class="description">${Text(_("We're sorry. There was a problem with the server while trying to process your last request. You may want to return to the {studio_name} Dashboard or try this request again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.")).format(
+          studio_name=settings.STUDIO_SHORT_NAME,
+          link_start=HTML(help_link_start),
+          link_end=HTML(help_link_end),
+        )}</p>
+    % endif
+    <a href="/" class="back-button">${_("Back to dashboard")}</a>
+  </article>
+</%block>

--- a/lms/templates/static_templates/404.html
+++ b/lms/templates/static_templates/404.html
@@ -1,0 +1,20 @@
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<%inherit file="../main.html" />
+
+<%block name="pagetitle">${_("Page Not Found")}</%block>
+
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="outside-app">
+    <h1>${_("Page not found")}</h1>
+    <p>${Text(_('The page that you were looking for was not found. Go back to the {link_start}homepage{link_end} or let us know about any pages that may have been moved at {email}.')).format(
+        link_start=HTML('<a href="/">'),
+        link_end=HTML('</a>'),
+        email=HTML('<a href="mailto:{email}">{email}</a>').format(email=Text(static.get_tech_support_email_address()))
+      )}</p>
+    </section>
+</main>

--- a/lms/templates/static_templates/server-error.html
+++ b/lms/templates/static_templates/server-error.html
@@ -1,0 +1,24 @@
+<%page expression_filter="h"/>
+<%namespace name='static' file='../static_content.html'/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<%inherit file="../main.html" />
+
+<main id="main" aria-label="Content" tabindex="-1">
+    <section class="outside-app">
+      <h1>
+        ${Text(_(u"There has been a 500 error on the {platform_name} servers")).format(
+            platform_name=HTML("<em>{platform_name}</em>").format(platform_name=Text(static.get_platform_name()))
+        )}
+      </h1>
+      <p>
+        ${Text(_('Please wait a few seconds and then reload the page. If the problem persists, please email us at {email}.')).format(
+            email=HTML('<a href="mailto:{email}">{email}</a>').format(
+                email=Text(static.get_tech_support_email_address())
+            )
+        )}
+      </p>
+    </section>
+</main>


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/salt-ops/issues/384

#### What's this PR do?
it adds error templates to mitx-theme, so that they can be loaded from theme, This will fix issue on case of crash

#### How should this be manually tested?
try to produce crash or call `/500` link

@pdpinch 