### PR TITLE
Removed registration link from header

### DIFF
--- a/lms/templates/navigation/navbar-not-authenticated.html
+++ b/lms/templates/navigation/navbar-not-authenticated.html
@@ -1,0 +1,52 @@
+## mako
+
+<%page expression_filter="h" args="online_help_token"/>
+
+<%namespace name='static' file='../static_content.html'/>
+<%namespace file='../main.html' import="login_query"/>
+<%!
+from django.core.urlresolvers import reverse
+from django.utils.translation import ugettext as _
+%>
+
+<ol class="left list-inline nav-global">
+  <%block name="navigation_global_links">
+    % if static.get_value('ENABLE_MKTG_SITE', settings.FEATURES.get('ENABLE_MKTG_SITE', False)):
+      <li class="item nav-global-01">
+        <a href="${marketing_link('HOW_IT_WORKS')}">${_("How it Works")}</a>
+      </li>
+      % if settings.FEATURES.get('COURSES_ARE_BROWSABLE'):
+        <li class="item nav-global-02">
+          <a href="${marketing_link('COURSES')}">${_("Courses")}</a>
+        </li>
+      % endif
+      <li class="item nav-global-03">
+        <a href="${marketing_link('SCHOOLS')}">${_("Schools")}</a>
+      </li>
+    % endif
+  </%block>
+
+  <%block name="navigation_other_global_links">
+    % if not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register:
+      % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
+        <li class="item nav-global-05">
+          <a class="btn" href="/courses">${_("Explore Courses")}</a>
+        </li>
+      %endif
+    % endif
+  </%block>
+</ol>
+
+<ol class="right nav-courseware list-inline">
+  <%block name="navigation_sign_in">
+    <li class="item nav-courseware-01">
+      % if not settings.FEATURES['DISABLE_LOGIN_BUTTON'] and not combined_login_and_register:
+        % if course and settings.FEATURES.get('RESTRICT_ENROLL_BY_REG_METHOD') and course.enrollment_domain:
+          <a class="btn btn-login" href="${reverse('course-specific-login', args=[course.id.to_deprecated_string()])}${login_query()}">${_("Sign in")}</a>
+        % else:
+          <a class="btn btn-login" href="/login${login_query()}">${_("Sign in")}</a>
+        % endif
+      % endif
+    </li>
+  </%block>
+</ol>


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/salt-ops/issues/469

#### What's this PR do?
It removes the registration link from header

#### How to test:
- Deploy theme
- Open lms url and look for registration link mentioned in issue 

@pdpinch 
#### Screenshot
<img width="1256" alt="screen shot 2017-11-20 at 4 35 22 pm" src="https://user-images.githubusercontent.com/10431250/33016795-b0208374-ce11-11e7-959c-06e322547580.png">

