### PR TITLE
reverting 8ac6f335773c0984bed7743baac6df24ff194beb

### DIFF
--- a/lms/static/sass/_overrides.scss
+++ b/lms/static/sass/_overrides.scss
@@ -89,33 +89,6 @@ ol.nav-global>li>a {
   font-size: 15px !important;
 }
 
-.window-wrap {
-    background-color: $container-bg;
-}
-
-.nav-main, .nav-global {
-    display: none !important;
-}
-
-.header-global.slim .course-header {
-    width: auto !important;
-}
-.header-global .user .user-link .label-username {
-    text-overflow: ellipsis !important;
-    overflow: hidden !important;
-    max-width: 180px !important;
-}
-
-.tab a {
-    color: $gray-d1 !important;
-    @include transition(all $tmg-f3 linear 0s);
-}
-
-.tabs .tab a.active, .tab a:hover {
-    border-bottom-color: rgb(6, 86, 131) !important;
-    color: rgb(6, 86, 131) !important;
-}
-
 @media print {
   .course-index {
       display: none !important;

--- a/lms/static/sass/partials/base/_variables.scss
+++ b/lms/static/sass/partials/base/_variables.scss
@@ -1,7 +1,7 @@
 @import 'lms/static/sass/partials/base/variables';
 
-$header-bg: white;
-$container-bg: white;
+$header-bg: rgba(186,186,187,0.75);
+$container-bg: #fbfbf9;
 $body-bg: #fbfbf9;
 
 $link-color: #a31f34;


### PR DESCRIPTION
#### What are the relevant tickets?

None. 

#### What's this PR do?

Reverts 8ac6f335773c0984bed7743baac6df24ff194beb because it removed the "Explore Courses" and "Sysadmin" links from the dashboard, not just the courseware page. 

It also incidentally reverts the color changes that were part of 8ac6f335773c0984bed7743baac6df24ff194beb

#### How should this be manually tested?

Confirm that the Find courses and Sysadmin links appear on the dashboard. The Sysadmin link will only appear for (django) admin users. 

#### Screenshots (if appropriate)

I'll add a screenshot if/when I can run this locally

