### PR TITLE
include course links in registration mail

### DIFF
--- a/lms/templates/emails/enroll_email_allowedmessage.txt
+++ b/lms/templates/emails/enroll_email_allowedmessage.txt
@@ -2,10 +2,10 @@
 
 ${_("Dear student,")}
 
-${_("You have been invited to join {course_name} at {site_name} by a "
+${_("You have been invited to join {course_name} at {course_url} by a "
     "member of the course staff.").format(
         course_name=display_name or course.display_name_with_default_escaped,
-        site_name=site_name
+        course_url=course_url
     )}
 % if is_shib_course:
 % if auto_enroll:
@@ -18,16 +18,16 @@ ${_("To access the course visit {course_about_url} and register for the course."
 % endif
 % else:
 
-${_("To finish your registration, please visit {site_name}/dashboard\n"
-        "You will need to login with Touchstone to access this page. If you "
-        "do not have a Touchstone account, please contact your instructor for "
-        "detailed directions.").format(
+${_("To access the course, you will first need to register for Residential MITx at {site_name}"
+        "with your Kerberos ID or Touchstone account."
+        "If you do not have a Kerberos ID and need to set up a Touchstone account,
+        "please contact your instructor for detailed directions.\n").format(
             site_name=site_name
     )}
 % if auto_enroll:
-${_("Once you have logged in with Touchstone, you will see "
-    "{course_name} listed on your dashboard.").format(
-        course_name=display_name or course.display_name_with_default_escaped
+${_("Once you have registered and logged in, visit the course site at "
+    "{course_about_url} to complete your enrollment.").format(
+        course_about_url=course_about_url
     )}
 % elif course_about_url is not None:
 ${_("Once you have logged in with Touchstone, visit {course_about_url} "


### PR DESCRIPTION
#### What are the relevant tickets?

fixes #57 

#### What's this PR do?

1) Includes the course URL in the registration email, in case the auto-enroll fails
2) Gives the student instructions on how to register and enroll in the course

#### How should this be manually tested?

I think easiest is for @mitodl/devops to deploy to the QA stack and then test there by enrolling e-mail addresses that don't yet have accounts. 

#### Any background context you want to provide?

This is partially motivated by https://github.mit.edu/mitx/Spring-2018/issues/41

