### PR TITLE
Revert changes to user dropdown

### DIFF
--- a/lms/static/sass/_overrides.scss
+++ b/lms/static/sass/_overrides.scss
@@ -112,16 +112,6 @@ ol.nav-global>li>a {
     background-color: $container-bg;
 }
 
-.global-header.slim .course-header {
-    width: auto !important;
-}
-
-.global-header .user .user-link .label-username, .dropdown-menu-container .menu-title {
-    text-overflow: ellipsis !important;
-    overflow: hidden !important;
-    max-width: 180px !important;
-}
-
 .tab a {
     color: $gray-d1 !important;
     @include transition(all $tmg-f3 linear 0s);


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/mitx-theme/issues/54

#### What's this PR do?
- It reverts drop down changes mention in issue, edX has fixed it on there behalf.

#### How should this be manually tested?
pull changes in theme and run `paver lms`

@pdpinch 
#### Screenshots (if appropriate)
<img width="945" alt="screen shot 2018-05-08 at 5 10 17 pm" src="https://user-images.githubusercontent.com/10431250/39757387-1d2d2c8e-52e6-11e8-81e3-a687c8490777.png">

