### PR TITLE
Better sorting of course codes

### DIFF
--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -30,7 +30,9 @@
             else:
               non_credit_courses.append(x)
         import re
-        credit_courses.sort(key=lambda x: float(re.sub(r'[^0-9\.]', '', x.display_number_with_default)))
+        credit_courses.sort(key=lambda x: float(
+          ".".join(re.sub(r'[^0-9\.]', '', x.display_number_with_default).split(".", 2)[:2])
+        ))
         %>
         <div class="courses" role="region" aria-label="${_('List of Courses')}">
           <ul class="courses-listing">


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #70

#### What's this PR do?
Sorts code codes like: `10.709.1`, `10.03/10.53/7.458/7.548`, `7.01.ASE_1`

#### How should this be manually tested?
Test with most complicated course codes.
