### PR TITLE
Fixed course experience page header

### DIFF
--- a/lms/static/sass/bootstrap/lms-main.scss
+++ b/lms/static/sass/bootstrap/lms-main.scss
@@ -1,0 +1,11 @@
+// -----------------------------
+// LMS main styles for Bootstrap
+// -----------------------------
+@import 'bourbon/bourbon'; // lib - bourbon
+@import 'vendor/bi-app/bi-app-ltr'; // set the layout for left to right languages
+
+@import 'edx-bootstrap/sass/open-edx/theme';
+@import 'lms/static/sass/partials/lms/theme/variables-v1.scss';
+@import 'lms/static/sass/bootstrap/lms-main.scss';
+@import "../partials/lms/theme/variables";
+@import "../overrides";


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/mitx-theme/issues/69

#### What's this PR do?
It fixed bootstrap theme to load mitX override classes.

#### How should this be manually tested?
Go to link http://localhost:8000/courses/(your-course-id)/course/ and check the header.

@pdpinch 

#### Screenshots (if appropriate)
<img width="1237" alt="screen shot 2018-05-17 at 4 45 28 pm" src="https://user-images.githubusercontent.com/10431250/40175643-3a240926-59f2-11e8-83e0-70c6eae576da.png">

