### PR TITLE
Fixed TemplateDoesNotExist head-extra.html

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -115,7 +115,6 @@ from pipeline_mako import render_require_js_path_overrides
 
   <%include file="/courseware/experiments.html"/>
   <%include file="user_metadata.html"/>
-  <%static:optional_include_mako file="head-extra.html" is_theming_enabled="True" />
 
   <%include file="widgets/optimizely.html" />
   <%include file="widgets/segment-io.html" />


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/mitx-theme/issues/71

#### What's this PR do?
it remove a line which is looking for  head-extra.html can casing exception.

#### How should this be manually tested?
Deploy theme in this branch and check if everything is working

@pdpinch 
#### Screenshots (if appropriate)
<img width="644" alt="screen shot 2018-05-18 at 4 30 28 pm" src="https://user-images.githubusercontent.com/10431250/40232584-d3a082f2-5ab8-11e8-830d-088f6120d8d6.png">

