### PR TITLE
Removed profile and account link for mitx instance

### DIFF
--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -1,0 +1,44 @@
+## mako
+<%page expression_filter="h"/>
+<%namespace name='static' file='static_content.html'/>
+
+## This template should not use the target student's details when masquerading, see TNL-4895
+<%
+self.real_user = getattr(user, 'real_user', user)
+%>
+
+<%!
+from django.core.urlresolvers import reverse
+from django.utils.translation import ugettext as _
+
+from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_image_urls_for_user
+from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
+
+%>
+
+<%
+    profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
+    username = self.real_user.username
+    resume_block = retrieve_last_sitewide_block_completed(username)
+%>
+
+
+<div class="nav-item hidden-mobile">
+    <a href="${reverse('dashboard')}" class="menu-title">
+        <img class="user-image-frame" src="${profile_image_url}" alt="">
+        <span class="sr-only">${_("Dashboard for:")}</span>
+        <span class="username">${username}</span>
+    </a>
+</div>
+<div class="nav-item hidden-mobile nav-item-dropdown" tabindex="-1">
+    <div class="toggle-user-dropdown" role="button" aria-label=${_("Options Menu")} aria-expanded="false" tabindex="0" aria-controls="user-menu">
+        <span class="fa fa-caret-down" aria-hidden="true"></span>
+    </div>
+    <div class="dropdown-user-menu hidden" aria-label=${_("More Options")} role="menu" id="user-menu" tabindex="-1">
+        % if resume_block:
+            <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${resume_block}" role="menuitem">${_("Resume your last course")}</a></div>
+        % endif
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('dashboard')}" role="menuitem">${_("Dashboard")}</a></div>
+        <div class="mobile-nav-item dropdown-item dropdown-nav-item"><a href="${reverse('logout')}" role="menuitem">${_("Sign Out")}</a></div>
+    </div>
+</div>


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/mitx-theme/issues/76

#### What's this PR do?
It removed account and profile from MITx theme. Because MIT uses touchstone for maintaining account s

#### How should this be manually tested?
Apply theme and go to dropdown and look for account and profile.

@pdpinch 

#### Screenshots (if appropriate)
<img width="209" alt="screen shot 2018-05-18 at 4 44 14 pm" src="https://user-images.githubusercontent.com/10431250/40233096-0c66eff2-5abb-11e8-9429-81812184fbd8.png">

