### PR TITLE
Remove courses when user is not logged in

### DIFF
--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -12,54 +12,57 @@
 <main id="main" aria-label="Content" tabindex="-1">
     <section class="find-courses">
       <section class="courses-container">
-        <%
-        courses.sort(key=lambda x: x.display_number_with_default)
-        codes = ['AS', 'CC', 'CMS', 'CSB', 'EC', 'EM', 'ES', 'HST', 'ISS', 'MAS', 'MS', 'NS', 'SCM', 'STS', 'WGS']
-        credit_courses = []
-        credit_courses_letter = []
-        non_credit_courses = []
-        for x in courses:
-          if x.display_number_with_default[0].isdigit():
-            if x.display_number_with_default.startswith('0'):
-              non_credit_courses.append(x)
+        %if user and user.is_authenticated():
+          <%
+          courses.sort(key=lambda x: x.display_number_with_default)
+          codes = ['AS', 'CC', 'CMS', 'CSB', 'EC', 'EM', 'ES', 'HST', 'ISS', 'MAS', 'MS', 'NS', 'SCM', 'STS', 'WGS']
+          credit_courses = []
+          credit_courses_letter = []
+          non_credit_courses = []
+          for x in courses:
+            if x.display_number_with_default[0].isdigit():
+              if x.display_number_with_default.startswith('0'):
+                non_credit_courses.append(x)
+              else:
+                credit_courses.append(x)
             else:
-              credit_courses.append(x)
-          else:
-            if x.display_number_with_default.startswith(tuple(codes)):
-              credit_courses_letter.append(x)
-            else:
-              non_credit_courses.append(x)
-        import re
-        credit_courses.sort(key=lambda x: float(
-          ".".join(re.sub(r'[^0-9\.]', '', x.display_number_with_default).split(".", 2)[:2])
-        ))
-        %>
-        <div class="courses" role="region" aria-label="${_('List of Courses')}">
-          <ul class="courses-listing">
+              if x.display_number_with_default.startswith(tuple(codes)):
+                credit_courses_letter.append(x)
+              else:
+                non_credit_courses.append(x)
+          import re
+          credit_courses.sort(key=lambda x: float(
+            ".".join(re.sub(r'[^0-9\.]', '', x.display_number_with_default).split(".", 2)[:2])
+          ))
+          %>
+          <div class="courses" role="region" aria-label="${_('List of Courses')}">
+            <ul class="courses-listing">
 
-            %for course in credit_courses:
-            <li class="courses-listing-item">
-              <%include file="../course.html" args="course=course" />
-            </li>
+              %for course in credit_courses:
+              <li class="courses-listing-item">
+                <%include file="../course.html" args="course=course" />
+              </li>
+              %endfor
+              %for course in credit_courses_letter:
+              <li class="courses-listing-item">
+                <%include file="../course.html" args="course=course" />
+              </li>
+              %endfor
+            </ul>
+
+          </div>
+          <div class="courses non-credit">
+            <ul class="courses-listing">
+             %for course in non_credit_courses:
+              <li class="courses-listing-item">
+                <%include file="../course.html" args="course=course" />
+              </li>
             %endfor
-            %for course in credit_courses_letter:
-            <li class="courses-listing-item">
-              <%include file="../course.html" args="course=course" />
-            </li>
-            %endfor
-          </ul>
-
-        </div>
-        <div class="courses non-credit">
-          <ul class="courses-listing">
-           %for course in non_credit_courses:
-            <li class="courses-listing-item">
-              <%include file="../course.html" args="course=course" />
-            </li>
-          %endfor
-          </ul>
-        </div>
-
+            </ul>
+          </div>
+        %else:
+          <p class="error">Please login first to see courses</p>
+        %endif
       </section>
     </section>
 </main>


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/salt-ops/issues/598

#### What's this PR do?
it hides courses when user is not logged in.

#### How should this be manually tested?
- Deploy theme 
- Open http://localhost:8000/courses without login
- Open http://localhost:8000/courses with login
- Open again http://localhost:8000/courses after logout

@pdpinch 

#### Screenshots (if appropriate)
<img width="1275" alt="screen shot 2018-05-30 at 6 39 32 pm" src="https://user-images.githubusercontent.com/10431250/40723864-3b4a0c14-6439-11e8-92f2-8155915ee931.png">

<img width="1272" alt="screen shot 2018-05-30 at 6 39 58 pm" src="https://user-images.githubusercontent.com/10431250/40723866-3b7965ae-6439-11e8-90d2-0182bd81a926.png">

