### PR TITLE
Fix enrollment email template

### DIFF
--- a/lms/templates/emails/enroll_email_allowedmessage.txt
+++ b/lms/templates/emails/enroll_email_allowedmessage.txt
@@ -19,10 +19,10 @@ ${_("To access the course visit {course_about_url} and register for the course."
 % else:
 
 ${_("To access the course, you will first need to register for Residential MITx at {site_name}"
-        "with your Kerberos ID or Touchstone account."
-        "If you do not have a Kerberos ID and need to set up a Touchstone account,
-        "please contact your instructor for detailed directions.\n").format(
-            site_name=site_name
+    "with your Kerberos ID or Touchstone account."
+    "If you do not have a Kerberos ID and need to set up a Touchstone account,"
+    "please contact your instructor for detailed directions.\n").format(
+        site_name=site_name
     )}
 % if auto_enroll:
 ${_("Once you have registered and logged in, visit the course site at "


### PR DESCRIPTION
#### What are the relevant tickets?
Fix issue with batch enrollment for courses  `SyntaxException: (SyntaxError) EOL while scanning string literal (<unknown>, line 3) (u'_("To access the course, you will first need to re') in file '/edx/app/edxapp/themes/mitx-theme/lms/templates/emails/enroll_email_allowedmessage.txt' at line: 21 char: 1`

#### What's this PR do?
Try to fix problem with template syntax.

#### How should this be manually tested?
(Required)

