### PR TITLE
New look message on /courses page

### DIFF
--- a/lms/templates/courseware/courses.html
+++ b/lms/templates/courseware/courses.html
@@ -10,6 +10,9 @@
 <%block name="pagetitle">${_("Courses")}</%block>
 
 <main id="main" aria-label="Content" tabindex="-1">
+  <p style="margin: 0 25px">New look, same page. We welcome your feedback:
+    <a href="mailto:mitx-support@mit.edu">mitx-support@mit.edu</a>
+  </p>
     <section class="find-courses">
       <section class="courses-container">
         %if user and user.is_authenticated():


### PR DESCRIPTION
#### What are the relevant tickets?
Fix #88
#### What's this PR do?
Add a message the top of the /courses page

#### How should this be manually tested?
Login and go to /courses

<img width="845" alt="screen shot 2018-06-19 at 12 34 58 pm" src="https://user-images.githubusercontent.com/7574259/41611243-4707bdce-73bd-11e8-8850-b8f6643efb0f.png">
