### PR TITLE
hide registration form

### DIFF
--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -55,7 +55,7 @@
     <div style="display: none" >
     <%= context.fields %>
     </div>
-    
+
     <div class="form-field checkbox-optional_fields_toggle">
         <input type="checkbox" id="toggle_optional_fields" class="input-block checkbox"">
         <label for="toggle_optional_fields">
@@ -66,7 +66,7 @@
     </div>
 
 
-    <button type="submit" class="action action-primary action-update js-register register-button">
+    <button style="display: none" type="submit" class="action action-primary action-update js-register register-button">
     	<% if ( context.registerFormSubmitButtonText ) { %><%- context.registerFormSubmitButtonText %><% } else { %><%- gettext("Create Account") %><% } %>
     </button>
 </form>

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -1,0 +1,69 @@
+<div class="js-form-feedback" aria-live="assertive" tabindex="-1">
+</div>
+
+<% if (!context.syncLearnerProfileData) { %>
+	<div class="toggle-form">
+		<span class="text"><%- edx.StringUtils.interpolate(gettext('Already have an {platformName} account?'), {platformName: context.platformName }) %></span>
+		<a href="#login" class="form-toggle" data-type="login"><%- gettext("Sign in.") %></a>
+	</div>
+<% } %>
+
+<form style="display: none" id="register" class="register-form" autocomplete="off" tabindex="-1" method="POST">
+
+    <% if (!context.currentProvider) { %>
+        <% if (context.providers.length > 0 || context.hasSecondaryProviders) { %>
+            <div class="login-providers">
+                <div class="section-title lines">
+                    <h3>
+                        <span class="text"><%- gettext("Create an account using") %></span>
+                    </h3>
+                </div>
+                <%
+                _.each( context.providers, function( provider) {
+                    if ( provider.registerUrl ) { %>
+                        <button type="button" class="button button-primary button-<%- provider.id %> login-provider register-<%- provider.id %>" data-provider-url="<%- provider.registerUrl %>">
+                            <div class="icon <% if ( provider.iconClass ) { %>fa <%- provider.iconClass %><% } %>" aria-hidden="true">
+                                <% if ( provider.iconImage ) { %>
+                                    <img class="icon-image" src="<%- provider.iconImage %>" alt="<%- provider.name %> icon" />
+                                <% } %>
+                            </div>
+                            <span aria-hidden="true"><%- provider.name %></span>
+                            <span class="sr"><%- _.sprintf( gettext("Create account using %(providerName)s."), {providerName: provider.name} ) %></span>
+                        </button>
+                <%  }
+                }); %>
+
+                <% if ( context.hasSecondaryProviders ) { %>
+                    <button type="button" class="button-secondary-login form-toggle" data-type="institution_login">
+                        <%- gettext("Use my institution/campus credentials") %>
+                    </button>
+                <% } %>
+            </div>
+            <div class="section-title lines">
+                <h3>
+                    <span class="text"><%- gettext("or create a new one here") %></span>
+                </h3>
+            </div>
+        <% } else { %>
+            <h2><%- gettext('Create an Account')%></h2>
+        <% } %>
+    <% } else if (context.autoRegisterWelcomeMessage) { %>
+        <span class="auto-register-message"><%- context.autoRegisterWelcomeMessage %></span>
+    <% } %>
+
+    <%= context.fields %>
+
+    <div class="form-field checkbox-optional_fields_toggle">
+        <input type="checkbox" id="toggle_optional_fields" class="input-block checkbox"">
+        <label for="toggle_optional_fields">
+            <span class="label-text">
+                <%- gettext("Support education research by providing additional information") %>
+            </span>
+        </label>
+    </div>
+
+
+    <button type="submit" class="action action-primary action-update js-register register-button">
+    	<% if ( context.registerFormSubmitButtonText ) { %><%- context.registerFormSubmitButtonText %><% } else { %><%- gettext("Create Account") %><% } %>
+    </button>
+</form>

--- a/lms/templates/student_account/register.underscore
+++ b/lms/templates/student_account/register.underscore
@@ -8,7 +8,7 @@
 	</div>
 <% } %>
 
-<form style="display: none" id="register" class="register-form" autocomplete="off" tabindex="-1" method="POST">
+<form id="register" class="register-form" autocomplete="off" tabindex="-1" method="POST">
 
     <% if (!context.currentProvider) { %>
         <% if (context.providers.length > 0 || context.hasSecondaryProviders) { %>
@@ -39,7 +39,7 @@
                     </button>
                 <% } %>
             </div>
-            <div class="section-title lines">
+            <div style="display: none" class="section-title lines">
                 <h3>
                     <span class="text"><%- gettext("or create a new one here") %></span>
                 </h3>
@@ -51,8 +51,11 @@
         <span class="auto-register-message"><%- context.autoRegisterWelcomeMessage %></span>
     <% } %>
 
+    <!-- wrapper to hide django-generated fields -->
+    <div style="display: none" >
     <%= context.fields %>
-
+    </div>
+    
     <div class="form-field checkbox-optional_fields_toggle">
         <input type="checkbox" id="toggle_optional_fields" class="input-block checkbox"">
         <label for="toggle_optional_fields">


### PR DESCRIPTION
#### What are the relevant tickets?

https://trello.com/c/fhJdQudZ/9-remove-create-account-link-from-course-about-pages

#### What's this PR do?

- Sets `display: none` on the registration form reachable from course about pages
- Does not 

#### How should this be manually tested?

- Logout
- Go to https://lms.mitx.mit.edu/register
- There should be no visible registration form

Note that the SAML account creation process apparently requires that this form exist, so it can't be removed wholesale. 

#### Where should the reviewer start?

Diff this override template with https://github.com/edx/edx-platform/blob/open-release/ironwood.master/lms/templates/student_account/register.underscore

#### Any background context you want to provide?

Classes start Monday at MIT, so it would be good to get this merged and released by then. 

#### Screenshots (if appropriate)

Need this

