### PR TITLE
Remove register link from Login page

### DIFF
--- a/lms/templates/student_account/login.underscore
+++ b/lms/templates/student_account/login.underscore
@@ -1,13 +1,6 @@
 <div class="js-form-feedback" aria-live="assertive" tabindex="-1">
 </div>
 
-<% if ( context.createAccountOption !== false && !context.syncLearnerProfileData && !(context.enterpriseName && context.currentProvider) ) { %>
-<div class="toggle-form">
-    <span class="text"><%- gettext("First time here?") %></span>
-    <a href="#login" class="form-toggle" data-type="register"><%- gettext("Create an Account.") %></a>
-</div>
-<% } %>
-
 <form id="login" class="login-form" tabindex="-1" method="POST">
 
     <% if ( context.providers.length > 0 && !context.currentProvider || context.hasSecondaryProviders ) { %>


### PR DESCRIPTION
#### What are the relevant tickets?
Fix https://github.mit.edu/mitx/Summer-2020/issues/13

#### What's this PR do?
Remove the link to register from the login page

#### How should this be manually tested?
<img width="459" alt="Screen Shot 2020-06-08 at 11 01 23 AM" src="https://user-images.githubusercontent.com/7574259/84045902-693c8e00-a977-11ea-8332-81efd6787c18.png">


