### PR TITLE
update progress template to include changes from PR #20084

### DIFF
--- a/lms/templates/courseware/progress.html
+++ b/lms/templates/courseware/progress.html
@@ -5,13 +5,21 @@
 <%!
 from course_modes.models import CourseMode
 from lms.djangoapps.certificates.models import CertificateStatuses
+from lms.djangoapps.grades.api import constants as grades_constants
 from django.utils.translation import ugettext as _
 from openedx.core.djangolib.markup import HTML, Text
 from django.urls import reverse
 from django.conf import settings
 from django.utils.http import urlquote_plus
 from six import text_type
+
+from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name
 %>
+
+<%
+username = get_enterprise_learner_generic_name(request) or student.username
+%>
+
 <%block name="bodyclass">view-in-course view-progress</%block>
 
 <%block name="headextra">
@@ -54,9 +62,11 @@ from six import text_type
                 </div>
                 % endif
                 <h2 class="hd hd-2 progress-certificates-title">
-                    ${_("Course Progress for Student '{username}' ({email})").format(username=student.username, email=student.email)}
+                    ${_("Course Progress for '{username}' ({email})").format(username=username, email=student.email)}
                 </h2>
-
+                <!-- removed conditional block with course_expiration_fragment -->
+                <!-- removed div containing certificate_block -->
+                
                 %if not course.disable_progress_graph:
                 <div class="grade-detail-graph" id="grade-detail-graph"></div>
                 %endif
@@ -133,21 +143,21 @@ from six import text_type
                                 %for section in chapter['sections']:
                                     <div>
                                         <%
-                                        earned = section.all_total.earned
-                                        total = section.all_total.possible
+                                        earned = section.graded_total.earned
+                                        total = section.graded_total.possible
 
-                                        percentageString = "{0:.0%}".format(section.percent_graded) if earned > 0 and total > 0 else ""
+                                        percentageString = "{0:.0%}".format(section.percent_graded) if total > 0 or earned > 0 else ""
                                         %>
                                         <h4 class="hd hd-4">
                                             <a href="${reverse('courseware_section', kwargs=dict(course_id=text_type(course.id), chapter=chapter['url_name'], section=section.url_name))}">
                                                 ${ section.display_name}
-                                                %if total > 0 or earned > 0:
+                                                %if (total > 0 or earned > 0) and section.show_grades(staff_access):
                                                 <span class="sr">
                                                     ${_("{earned} of {total} possible points").format(earned='{:.3n}'.format(float(earned)), total='{:.3n}'.format(float(total)))}
                                                 </span>
                                                 %endif
                                             </a>
-                                            %if total > 0 or earned > 0:
+                                            %if (total > 0 or earned > 0) and section.show_grades(staff_access):
                                             <span> ${"({0:.3n}/{1:.3n}) {2}".format( float(earned), float(total), percentageString )}</span>
                                             %endif
                                         </h4>
@@ -155,13 +165,14 @@ from six import text_type
                                             %if section.format is not None:
                                                 ${section.format}
                                             %endif
-                                            %if section.due is not None:
+                                            %if section.due is not None and pacing_type != 'self_paced':
                                                 <em class="localized-datetime" data-datetime="${section.due}" data-string="${_('due {date}')}" data-timezone="${user_timezone}" data-language="${user_language}"></em>
                                             %endif
                                         </p>
                                         <p class="override-notice">
                                             %if section.override is not None:
-                                                %if section.format is not None and section.format == "Exam":
+                                                <%last_override_history = section.override.get_history().order_by('created').last()%>
+                                                %if (not last_override_history or last_override_history.system == grades_constants.GradeOverrideFeatureEnum.proctoring) and section.format == "Exam" and earned == 0:
                                                     ${_("Suspicious activity detected during proctored exam review. Exam score 0.")}
                                                 %else:
                                                     ${_("Section grade has been overridden.")}


### PR DESCRIPTION
#### What are the relevant tickets?

None. 

#### What's this PR do?

Trying to get the changes made in https://github.com/edx/edx-platform/pull/20084 to work on MITx Residential. It appears that the changes are overridden by this theme. 

See [this Slack chat](https://mitodl.slack.com/archives/G2E5J5CF5/p1596817440052400) for more details. 

#### How should this be manually tested?

On Residential MITx, using the current theme, look at my progress page:

https://staging.mitx.mit.edu/courses/course-v1:TestX+Test101+2T2020/progress/5/

Or on MITx-qa-next, also using the current theme:

https://mitx-qa-next.mitx.mit.edu/courses/course-v1:TestX+Test101+2T2020/progress/8/

![image](https://user-images.githubusercontent.com/430126/89716865-aaa0e800-d97e-11ea-962f-c833185facd8.png)

Note that even thought the assessment results have been hidden, you can still see "1/3" and percentage text. https://github.com/edx/edx-platform/pull/20084 should have hidden that. 


After applying this change, the text "(1/3) 33%" should be omitted. 

There is also a test in https://github.com/edx/edx-platform/pull/20084 that can be used to verify this change. I presume that if you run the test with the current theme, it will fail.

