### PR TITLE
Override contact us page

### DIFF
--- a/lms/templates/support/contact_us.html
+++ b/lms/templates/support/contact_us.html
@@ -1,0 +1,31 @@
+<%!
+from django.utils.translation import ugettext as _
+%>
+
+<%inherit file="../main.html"/>
+
+<%block name="title">
+    <title>
+        ${_("Contact {platform_name} Support").format(platform_name=platform_name)}
+    </title>
+</%block>
+
+<%block name="head_extra">
+    <link type="text/css" rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+</%block>
+
+<main id="main" aria-label="Content">
+
+    <div id="root" class="container">
+        <h2 class="heading-left">${_("Contact Us")}</h2>
+        <p style="padding-top: 16px">
+            Find answers to common questions in the <a class="nav-link"
+            href='https://edx.readthedocs.io/projects/open-edx-building-and-running-a-course/en/latest/'>Open edX
+            documentation.</a>
+        </p>
+        <p>
+            For other support questions, please reach out to <a
+            href="mailto:mitx-support@mit.edu">mitx-support@mit.edu</a>.
+        </p>
+    </div>
+</main>


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #127 

#### What's this PR do?
It creates/overrides our own contact us page with specific content mentioned in the associated ticket.

#### How should this be manually tested?
On your LMS, Go to `/support/contact_us` page and you should just see two links there as mentioned in the ticket.

#### Screenshots (if appropriate)
<img width="762" alt="Screenshot 2020-12-07 at 6 31 21 PM" src="https://user-images.githubusercontent.com/34372316/101357073-c7144900-38ba-11eb-9772-48ee36b62d95.png">
