### PR TITLE
add sysadmin tab and use absolute imports

### DIFF
--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -3,10 +3,10 @@
 from django.utils.translation import ugettext as _
 from django.utils.translation import pgettext
 from django.urls import reverse
-from courseware.courses import get_course_about_section
+from lms.djangoapps.courseware.courses import get_course_about_section
 from django.conf import settings
 from six import text_type
-from edxmako.shortcuts import marketing_link
+from common.djangoapps.edxmako.shortcuts import marketing_link
 from openedx.core.djangolib.markup import HTML
 from openedx.core.lib.courses import course_image_url
 from six import string_types
@@ -173,7 +173,7 @@ from six import string_types
           </a>
           <div id="register_error"></div>
         %else:
-          <% 
+          <%
             if ecommerce_checkout:
               reg_href = ecommerce_checkout_link
             else:

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -1,7 +1,7 @@
 ## mako
 <%!
   from django.utils.translation import ugettext as _
-  from branding.api import get_footer
+  from lms.djangoapps.branding.api import get_footer
 %>
 <% footer = get_footer(is_secure=is_secure) %>
 <%namespace name='static' file='static_content.html'/>

--- a/lms/templates/header/navbar-authenticated.html
+++ b/lms/templates/header/navbar-authenticated.html
@@ -11,8 +11,15 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
 %>
 
 <%
+  try:
+    from edx_sysadmin.utils.utils import show_sysadmin_dashboard
+    sysadmin_dashboard = show_sysadmin_dashboard(user)
+  except:
+    sysadmin_dashboard = None
+%>
+
+<%
   show_explore_courses = settings.FEATURES.get('COURSES_ARE_BROWSABLE') and not show_program_listing
-  show_sysadmin_dashboard = settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD','') and user.is_staff
   self.real_user = getattr(user, 'real_user', user)
 %>
 
@@ -37,10 +44,10 @@ from openedx.core.djangoapps.site_configuration import helpers as configuration_
         <a class="tab-nav-link" href="${marketing_link('COURSES')}">${_('Discover New')}</a>
       </div>
     % endif
-    % if show_sysadmin_dashboard:
+    % if sysadmin_dashboard:
       <div class="mobile-nav-item hidden-mobile nav-item nav-tab">
         ## Translators: This is short for "System administration".
-        <a class="tab-nav-link" href="${reverse('sysadmin')}">${_("Sysadmin")}</a>
+        <a class="tab-nav-link" href="${reverse('sysadmin:sysadmin')}">${_("Sysadmin")}</a>
       </div>
     % endif
   </div>

--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -13,13 +13,13 @@
 <%namespace name='static' file='static_content.html'/>
 <% online_help_token = self.online_help_token() if hasattr(self, 'online_help_token') else None %>
 <%!
-from branding import api as branding_api
+from lms.djangoapps.branding import api as branding_api
 from django.urls import reverse
 from django.utils.http import urlquote_plus
 from django.utils.translation import ugettext as _
 from django.utils.translation import get_language_bidi
 from openedx.core.djangolib.js_utils import dump_js_escaped_json, js_escaped_string
-from pipeline_mako import render_require_js_path_overrides
+from common.djangoapps.pipeline_mako import render_require_js_path_overrides
 
 %>
 <!DOCTYPE html>
@@ -161,7 +161,7 @@ from pipeline_mako import render_require_js_path_overrides
     % endif
 
     <%include file="/page_banner.html" />
-    
+
     <div class="marketing-hero"><%block name="marketing_hero"></%block></div>
 
     <div class="content-wrapper main-container" id="content">

--- a/lms/templates/navigation/bootstrap/navbar-authenticated.html
+++ b/lms/templates/navigation/bootstrap/navbar-authenticated.html
@@ -9,6 +9,14 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 
+<%
+  try:
+    from edx_sysadmin.utils.utils import show_sysadmin_dashboard
+    sysadmin_dashboard = show_sysadmin_dashboard(user)
+  except:
+    sysadmin_dashboard = None
+%>
+
 <div class="collapse navbar-collapse" id="navbarSupportedContent">
   <ul class="navbar-nav mr-auto">
      % if course:
@@ -46,10 +54,10 @@ from django.utils.translation import ugettext as _
       </li>
     % endif
 
-    % if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD','') and user.is_staff:
+    % if sysadmin_dashboard:
       <li class="nav-item mt-2 nav-item-open-collapsed">
         ## Translators: This is short for "System administration".
-        <a class="nav-link" href="${reverse('sysadmin')}">${_("Sysadmin")}</a>
+        <a class="nav-link" href="${reverse('sysadmin:sysadmin')}">${_("Sysadmin")}</a>
       </li>
     % endif
   </ul>

--- a/lms/templates/navigation/bootstrap/navbar-logo-header.html
+++ b/lms/templates/navigation/bootstrap/navbar-logo-header.html
@@ -7,7 +7,7 @@
 from django.utils.translation import ugettext as _
 
 # App that handles subdomain specific branding
-from branding import api as branding_api
+from lms.djangoapps.branding import api as branding_api
 %>
 
 <a class="navbar-brand" href="${marketing_link('ROOT')}">

--- a/lms/templates/navigation/navbar-authenticated.html
+++ b/lms/templates/navigation/navbar-authenticated.html
@@ -9,6 +9,14 @@ from django.urls import reverse
 from django.utils.translation import ugettext as _
 %>
 
+<%
+  try:
+    from edx_sysadmin.utils.utils import show_sysadmin_dashboard
+    sysadmin_dashboard = show_sysadmin_dashboard(user)
+  except:
+    sysadmin_dashboard = None
+%>
+
 <ol class="left nav-global list-inline authenticated">
   <%block name="navigation_global_links_authenticated">
     % if settings.FEATURES.get('COURSES_ARE_BROWSABLE') and not show_program_listing:
@@ -28,10 +36,10 @@ from django.utils.translation import ugettext as _
         </a>
       </li>
     % endif
-    %if settings.FEATURES.get('ENABLE_SYSADMIN_DASHBOARD','') and user.is_staff:
+    %if sysadmin_dashboard:
       <li class="item">
         ## Translators: This is short for "System administration".
-        <a href="${reverse('sysadmin')}">${_("Sysadmin")}</a>
+        <a href="${reverse('sysadmin:sysadmin')}">${_("Sysadmin")}</a>
       </li>
     %endif
   </%block>

--- a/lms/templates/navigation/navbar-logo-header.html
+++ b/lms/templates/navigation/navbar-logo-header.html
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext as _
 from lms.djangoapps.ccx.overrides import get_current_ccx
 
 # App that handles subdomain specific branding
-from branding import api as branding_api
+from lms.djangoapps.branding import api as branding_api
 %>
 
 <h1 class="hd logo-header">

--- a/lms/templates/navigation/navigation.html
+++ b/lms/templates/navigation/navigation.html
@@ -12,7 +12,7 @@ from lms.djangoapps.ccx.overrides import get_current_ccx
 from openedx.core.djangolib.markup import HTML, Text
 
 # App that handles subdomain specific branding
-from branding import api as branding_api
+from lms.djangoapps.branding import api as branding_api
 # app that handles site status messages
 from status.status import get_site_status_msg
 from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/edx-platform/issues/250

#### What's this PR do?
* Adds sysadmin tab,  which will be shown only when edx-sysadmin plugin is installed.
* Replaces relative paths with absolute ones. 

#### How should this be manually tested?
* Install edx-sysadmin
* Add mitx-theme
* You will start see sysadmin tab

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/42243411/113289317-7ad99280-9309-11eb-88be-6e177daabeff.png)

![image](https://user-images.githubusercontent.com/42243411/113289343-8036dd00-9309-11eb-8740-8ff0f418857e.png)
