### PR TITLE
fix: broken theme when completion tracking switch is on

### DIFF
--- a/lms/templates/header/user_dropdown.html
+++ b/lms/templates/header/user_dropdown.html
@@ -19,7 +19,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewi
 <%
     profile_image_url = get_profile_image_urls_for_user(self.real_user)['medium']
     username = self.real_user.username
-    resume_block = retrieve_last_sitewide_block_completed(username)
+    resume_block = retrieve_last_sitewide_block_completed(self.real_user)
 %>
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/edx-platform/issues/304

#### What's this PR do?
- Fixes a data issue when `completion.enable_completion_tracking` switch is turned on.
- Our theme has been outdated as of late and we probably never turned completion on for residential.
- This PR passes the user instance to the completion method instead of the username since the [completion function expects a user](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/user_api/accounts/utils.py#L114).

#### How should this be manually tested?
- Would be a good idea to first reproduce this issue
- The checkout this branch and check that the theme doesn't break and works normally
- Before going through a course you should see `View Course` button
- But when you visit a course and complete a block, You should see `Resume Course` button on the dashboard list as show in the screenshot below.

#### Where should the reviewer start?
Setup of this theme with the master branch

#### Any background context you want to provide?


#### Screenshots (if appropriate)
When the course is not resumable
<img width="1573" alt="image" src="https://user-images.githubusercontent.com/34372316/210525426-c8d6d777-5395-4f2b-9a90-afdb36f6dd57.png">

When the course is resumable
<img width="1377" alt="image" src="https://user-images.githubusercontent.com/34372316/210533819-5590492c-fd1c-4646-a948-97cc317d8ea7.png">

