### PR TITLE
fix: logout url

### DIFF
--- a/cms/templates/widgets/user_dropdown.html
+++ b/cms/templates/widgets/user_dropdown.html
@@ -26,7 +26,7 @@
               </li>
           </%block>
           <li class="dropdown-item item has-block-link">
-            <a class="action action-signout" href="${reverse('logout')}">${_("Sign Out")}</a>
+            <a class="action action-signout" href="${settings.FRONTEND_LOGOUT_URL}">${_("Sign Out")}</a>
           </li>
       </ul>
   </div>
@@ -47,7 +47,7 @@
           <a href="/">${_("{studio_name} Home").format(studio_name=settings.STUDIO_SHORT_NAME)}</a>
         </li>
         <li class="nav-item nav-account-signout">
-          <a class="action action-signout" href="${reverse('logout')}">${_("Sign Out")}</a>
+          <a class="action action-signout" href="${settings.FRONTEND_LOGOUT_URL}">${_("Sign Out")}</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/4500

#### What does this PR do?
The current logout URL does not have a trailing backslash. This PR makes changes and uses a setting instead of reverse('logout'). The usage of the setting is consistent with the[ MITx Online theme](https://github.com/mitodl/mitxonline-theme/blob/main/cms/templates/widgets/user_dropdown.html).

#### How should this be manually tested?

- On master, Try to setup the theme by following the Readme
- Check if the Sign-out URL in the user dropdown has a trailing slash. It will render the Django template.
- If your theme is not working as it was the case for me. Then replace the contents of `cms/templates/widgets/user_dropdown.html` with the user_dropdown.html in this theme.
- Repeat the steps with this branch and logout should work fine.
