### PR TITLE
fix: show accessibility and tos links

### DIFF
--- a/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/lms/static/sass/partials/lms/theme/_extras.scss
@@ -1,0 +1,215 @@
+// Shared design tokens to keep typography and color usage consistent across the LMS theme.
+$font-stack-system: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial,
+        "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol",
+        "Noto Color Emoji";
+$font-size-ui: 1.125rem;
+$color-surface-muted: #f7f7f7;
+$color-surface-default: #ffffff;
+$color-surface-border: #e0e0e0;
+$color-brand-primary: rgba(0, 109, 170, 1);
+$color-text-muted: rgb(69, 69, 69);
+$color-text-emphasis: rgb(10, 48, 85);
+$color-hover-neutral: rgb(233, 230, 228);
+$color-background-alt: rgb(240, 243, 245);
+$color-background-soft: rgb(240, 238, 237);
+$color-border-strong: rgb(7, 34, 60);
+$color-border-subtle: rgba(0, 0, 0, 0.15);
+$color-hover-link: rgb(0, 60, 94);
+
+body{
+  font-family: $font-stack-system !important;
+}
+
+.container-fluid.wrapper-footer,
+.wrapper.wrapper-footer {
+  background: $color-surface-muted;
+  padding: 0;
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  border: none !important;
+
+  &,
+  &.wrapper-footer {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  .mit-footer {
+    background: $color-surface-default;
+    box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.08);
+    width: 100%;
+    max-width: none;
+    padding: 32px 40px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    font-family: $font-stack-system;
+
+    .mit-footer__inner {
+      display: flex;
+      justify-content: space-between;
+      align-items: stretch;
+      gap: 48px;
+      width: 100%;
+    }
+
+    .mit-footer__column {
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .mit-footer__column--brand {
+      flex: 0 0 160px;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      min-height: 33px;
+
+      .mit-footer__logo {
+        display: inline-flex;
+        align-items: center;
+        justify-content: flex-start;
+
+        img {
+          height: 33px;
+          width: auto;
+          max-height: 33px;
+          display: block;
+        }
+      }
+    }
+
+    .mit-footer__column--links {
+      flex: 1 1 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+
+      .mit-footer__nav {
+        width: 100%;
+
+        .mit-footer__menu {
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          display: flex;
+          flex-wrap: wrap;
+          justify-content: center;
+          column-gap: 18px;
+          row-gap: 2px;
+
+          .mit-footer__menu-item {
+            a {
+              color: $color-brand-primary;
+              font-size: $font-size-ui;
+              font-weight: 400;
+              line-height: 1.4;
+              text-decoration: none;
+
+              &:hover,
+              &:focus {
+                color: $color-hover-link;
+                text-decoration: underline;
+              }
+            }
+          }
+        }
+      }
+
+      .mit-footer__legal {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        color: #4a4a4a;
+        font-size: 13.5px;
+        align-items: center;
+        text-align: center;
+
+        p {
+          margin: 0;
+        }
+      }
+    }
+
+    .mit-footer__column--actions {
+      flex: 0 0 200px;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      gap: 24px;
+      text-align: right;
+
+      .mit-footer__language {
+        .footer-language-selector {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-end;
+          gap: 8px;
+        }
+      }
+
+      .mit-footer__powered-link {
+        display: inline-flex;
+        align-items: center;
+
+        img {
+          width: 120px;
+          height: auto;
+        }
+      }
+    }
+  }
+}
+
+body.view-in-course {
+  .wrapper-footer,
+  .wrapper.wrapper-footer,
+  .container-fluid.wrapper-footer {
+    margin-top: 0;
+  }
+}
+
+@media (max-width: 767.98px) {
+  .container-fluid.wrapper-footer,
+  .wrapper.wrapper-footer {
+    .mit-footer {
+      padding: 24px 20px;
+
+      .mit-footer__inner {
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 16px;
+      }
+
+      .mit-footer__column--brand,
+      .mit-footer__column--actions {
+        flex: 0 0 auto;
+        width: auto;
+        align-items: flex-start;
+      }
+
+      .mit-footer__column--links {
+        flex: 1 1 0;
+
+        .mit-footer__nav {
+          .mit-footer__menu {
+            flex-direction: column;
+            align-items: center;
+            column-gap: 0;
+            row-gap: 2px;
+          }
+        }
+
+        .mit-footer__legal p {
+          text-align: center;
+          align-items: center;
+        }
+      }
+    }
+  }
+}

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -12,6 +12,7 @@
 
   icp_license = getattr(settings,'ICP_LICENSE', False)
   icp_markup = u" | {icp}".format(icp=icp_license) if icp_license else ""
+  brand_home_url = getattr(settings, "MIT_OPEN_LEARNING_SITE_LINK", "https://openlearning.mit.edu/")
 
   footer_links = {
     "terms_of_service": {"url": None, "title": "Terms of Service"},
@@ -34,7 +35,7 @@
   <footer class="mit-footer"${(' dir="%s"' % bidi) if bidi else ''}>
     <div class="mit-footer__inner">
       <div class="mit-footer__column mit-footer__column--brand">
-        <a class="mit-footer__logo" href="${settings.MIT_BASE_URL}">
+        <a class="mit-footer__logo" href="${brand_home_url}">
           <img src="${footer['logo_image']}" alt="${platform_name}" />
         </a>
       </div>

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -7,7 +7,7 @@
 %>
 <%
   footer = get_footer(is_secure=request.is_secure())
-  footer['copyright'] = _(u"\u00A9 {year} Massachusetts Institute of Technology").format(year=datetime.now().year)
+  footer['copyright'] = _(u"\u00A9 {year} MITx Residential. All rights reserved.").format(year=datetime.now().year)
   footer['navigation_links'] = [link for link in footer['navigation_links'] if link.get("name")!="help-center"]
 
   icp_license = getattr(settings,'ICP_LICENSE', False)

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -26,11 +26,17 @@
             <a href="https://openlearning.mit.edu">
               <img alt="${footer['openedx_link']['title']}" src="${footer['logo_image']}">
             </a>
-              % for item_num, link in enumerate(footer['legal_links'], start=1):
-                %if link['name'] in ['terms_of_service', 'accessibility_policy']:
-                  <a href="${link['url']}" style="margin-top:6px;">${link['title']}</a>
+            <span style="display: inline-flex; align-items: center; white-space: nowrap;">
+              <%
+                filtered_links = [link for link in footer['legal_links'] if link['name'] in ['terms_of_service', 'accessibility_policy']]
+              %>
+              % for item_num, link in enumerate(filtered_links, start=1):
+                %if item_num > 1:
+                <span style="margin: 0 4px;"> - </span>
                 %endif
+                <a href="${link['url']}">${link['title']}</a>
               % endfor
+            </span>
           </div>
           % endif
           <address style="font-size: 11px;">600 Technology Square, Cambridge, MA 02139</address>

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -27,8 +27,8 @@
               <img alt="${footer['openedx_link']['title']}" src="${footer['logo_image']}">
             </a>
               % for item_num, link in enumerate(footer['legal_links'], start=1):
-                %if link['title'] == "Terms of Service":
-                    <a href="${link['url']}" style="margin-top:6px;">${link['title']}</a>
+                %if link['name'] in ['terms_of_service', 'accessibility_policy']:
+                  <a href="${link['url']}" style="margin-top:6px;">${link['title']}</a>
                 %endif
               % endfor
           </div>

--- a/lms/templates/footer.html
+++ b/lms/templates/footer.html
@@ -2,48 +2,85 @@
 <%!
   from django.utils.translation import gettext as _
   from lms.djangoapps.branding.api import get_footer
+  from django.conf import settings
+  from datetime import datetime
 %>
-<% footer = get_footer(is_secure=is_secure) %>
+<%
+  footer = get_footer(is_secure=request.is_secure())
+  footer['copyright'] = _(u"\u00A9 {year} Massachusetts Institute of Technology").format(year=datetime.now().year)
+  footer['navigation_links'] = [link for link in footer['navigation_links'] if link.get("name")!="help-center"]
+
+  icp_license = getattr(settings,'ICP_LICENSE', False)
+  icp_markup = u" | {icp}".format(icp=icp_license) if icp_license else ""
+
+  footer_links = {
+    "terms_of_service": {"url": None, "title": "Terms of Service"},
+    "accessibility_policy": {"url": None, "title": "Accessibility"},
+  }
+  for link in footer['legal_links']:
+      url = link.get('url')
+      name = link.get('name')
+      if not url or name not in footer_links.keys():
+          continue
+      footer_links[link["name"]]["url"] = url
+%>
 <%namespace name='static' file='static_content.html'/>
 
-## WARNING: These files are specific to edx.org and are not used in installations outside of that domain. Open edX users will want to use the file "footer.html" for any changes or overrides.
-<footer id="footer-edx-v3" role="contentinfo" aria-label="${_("Page Footer")}"
-  ## When rendering the footer through the branding API,
-  ## the direction may not be set on the parent element,
-  ## so we set it here.
-  % if bidi:
-    dir=${bidi}
-  % endif
->
-    <h2 class="sr footer-about-title">${_("About MITx")}</h2>
-    <div class="footer-content-wrapper">
-      <div class="site-details">
-          ## The OpenEdX link may be hidden when this view is served
-          ## through an API to partner sites (such as marketing sites or blogs),
-          ## which are not technically powered by OpenEdX.
-          % if not hide_openedx_link:
-          <div class="openedx-link" style="margin-left: 6px; font-size: 11px;">
-            <a href="https://openlearning.mit.edu">
-              <img alt="${footer['openedx_link']['title']}" src="${footer['logo_image']}">
-            </a>
-            <span style="display: inline-flex; align-items: center; white-space: nowrap;">
-              <%
-                filtered_links = [link for link in footer['legal_links'] if link['name'] in ['terms_of_service', 'accessibility_policy']]
-              %>
-              % for item_num, link in enumerate(filtered_links, start=1):
-                %if item_num > 1:
-                <span style="margin: 0 4px;"> - </span>
-                %endif
-                <a href="${link['url']}">${link['title']}</a>
-              % endfor
-            </span>
-          </div>
-          % endif
-          <address style="font-size: 11px;">600 Technology Square, Cambridge, MA 02139</address>
+<%
+  footer_css_urls = context.get('footer_css_urls', [])
+%>
 
+<%def name="render_footer()">
+  <footer class="mit-footer"${(' dir="%s"' % bidi) if bidi else ''}>
+    <div class="mit-footer__inner">
+      <div class="mit-footer__column mit-footer__column--brand">
+        <a class="mit-footer__logo" href="${settings.MIT_BASE_URL}">
+          <img src="${footer['logo_image']}" alt="${platform_name}" />
+        </a>
+      </div>
+      <div class="mit-footer__column mit-footer__column--links">
+        <nav class="mit-footer__nav" aria-label="${_('Footer navigation')}">
+          <ul class="mit-footer__menu">
+            % for key, value in footer_links.items():
+              <li class="mit-footer__menu-item">
+                <a href="${value['url']}">${value['title']}</a>
+              </li>
+            % endfor
+          </ul>
+        </nav>
+        ## Site operators: Please do not remove this paragraph! This attributes back to edX and makes your acknowledgement of edX's trademarks clear.
+        <div class="mit-footer__legal">
+          <p class="mit-footer__copyright">${footer['copyright']}${icp_markup}</p>
+          <p class="mit-footer__trademark">
+            ${_(u"edX and Open edX are registered trademarks of edX LLC.")}
+          </p>
         </div>
+      </div>
+      <div class="mit-footer__column mit-footer__column--actions">
+        % if context.get('include_language_selector', False):
+          <div class="mit-footer__language">
+            <%include file="${static.get_template_path('widgets/footer-language-selector.html')}"/>
+          </div>
+        % endif
+        <div class="mit-footer__powered">
+          <a href="https://openedx.org" class="mit-footer__powered-link">
+            <img src="https://logos.openedx.org/open-edx-logo-tag.png" alt="Open edX" />
+          </a>
+        </div>
+      </div>
     </div>
-</footer>
+  </footer>
+</%def>
+
+% if uses_bootstrap:
+  <div class="container-fluid wrapper-footer">
+    ${render_footer()}
+  </div>
+% else:
+  <div class="wrapper wrapper-footer">
+    ${render_footer()}
+  </div>
+% endif
 % if include_dependencies:
   <%static:js group='base_vendor'/>
   <%static:css group='style-vendor'/>


### PR DESCRIPTION
#### What are the relevant tickets?
[#8757](https://github.com/mitodl/hq/issues/8757)

#### What's this PR do?
The footer template was filtering legal links by checking for an exact title match (`link['title'] == "Terms of Service"`), which caused two issues:

a. **Excluded the accessibility link entirely** - only TOS was checked, other links were ignored
b. **Title match failed** - even though the title key is available but some string mismatching excluded that from the filtering too, using exact names seemed a more viable option.

This PR addresses these issues with the following changes:
- Changed from checking `link['title']` to checking `link['name']` 
- Updated filter to include both `'terms_of_service'` and `'accessibility_policy'`

#### Screenshots

Before:
<img width="994" height="264" alt="Screenshot 2025-10-29 at 4 46 02 PM" src="https://github.com/user-attachments/assets/9b0a1f8c-8020-4cd8-bd4c-1d7025d7af8a" />

After:
<img width="2880" height="294" alt="Screenshot 2025-10-31 at 9 41 51 AM" src="https://github.com/user-attachments/assets/338b3070-654d-4c0f-bb25-f9da48ab0d4f" />

<img width="416" height="284" alt="Screenshot 2025-10-31 at 9 42 54 AM" src="https://github.com/user-attachments/assets/8e9ab505-d91b-4a31-a800-ecdab41bf393" />

#### How should this be manually tested?

1. Navigate to any LMS page (homepage, course page, etc.) - (will need to disable Learning MFE)
2. Scroll to the footer
3. Look for the legal links section (near the MIT Resedential logo)

Expected Result:

- "Terms of Service" link is visible
-  "Accessibility Policy" link is visible
